### PR TITLE
require erb lib

### DIFF
--- a/lib/rom/cassandra/migrations/generator.rb
+++ b/lib/rom/cassandra/migrations/generator.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'erb'
+
 module ROM::Cassandra
 
   module Migrations


### PR DESCRIPTION
To prevent this error

```
$ bundle exec rake db:create_migration[create_users] --trace
** Invoke db:create_migration (first_time)
** Execute db:create_migration
rake aborted!
NameError: uninitialized constant ROM::Cassandra::Migrations::Generator::ERB
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rom-cassandra-0.0.2/lib/rom/cassandra/migrations/generator.rb:53:in `content'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rom-cassandra-0.0.2/lib/rom/cassandra/migrations/generator.rb:43:in `call'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rom-cassandra-0.0.2/lib/rom/cassandra/migrations/generator.rb:22:in `call'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rom-cassandra-0.0.2/lib/tasks/db.rake:13:in `block (2 levels) in <top (required)>'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `call'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:240:in `block in execute'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `each'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:235:in `execute'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/opt/ruby-2.1.7/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:172:in `invoke_with_call_chain'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/task.rb:165:in `invoke'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:150:in `invoke_task'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `each'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:106:in `block in top_level'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:115:in `run_with_threads'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:100:in `top_level'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:78:in `block in run'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:176:in `standard_exception_handling'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/lib/rake/application.rb:75:in `run'
/opt/ruby-2.1.7/lib/ruby/gems/2.1.0/gems/rake-10.4.2/bin/rake:33:in `<top (required)>'
/opt/ruby-2.1.7/bin/rake:23:in `load'
/opt/ruby-2.1.7/bin/rake:23:in `<main>'
Tasks: TOP => db:create_migration
```
